### PR TITLE
Add torch find-links to requirements-gpu

### DIFF
--- a/requirements-gpu.txt
+++ b/requirements-gpu.txt
@@ -11,6 +11,8 @@ h5py
 imgaug
 IPython[all]
 pandas>=0.23.1
+# Inform pip where to find torch
+--find-links https://download.pytorch.org/whl/torch_stable.html
 torch==0.4.1
 torchvision>=0.2.1
 ffmpeg-python


### PR DESCRIPTION
This solves the version matching errors described in the Install_and_Tutorial without having to use the conda install method.